### PR TITLE
fix default_power_ids for nil powers

### DIFF
--- a/lib/consul/power.rb
+++ b/lib/consul/power.rb
@@ -44,7 +44,11 @@ module Consul
     def default_power_ids(power_name, *args)
       scope = send(power_name, *args)
       database_touched
-      scope.collect_ids
+      if scope
+        scope.collect_ids
+      else
+        []
+      end
     end
 
     def powerless!(*args)

--- a/lib/consul/version.rb
+++ b/lib/consul/version.rb
@@ -1,3 +1,3 @@
 module Consul
-  VERSION = '0.12.0'
+  VERSION = '0.12.1'
 end

--- a/spec/rails-2.3/Gemfile.lock
+++ b/spec/rails-2.3/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    consul (0.12.0)
+    consul (0.12.1)
       edge_rider (>= 0.3.0)
       memoizer
       rails

--- a/spec/rails-3.0/Gemfile.lock
+++ b/spec/rails-3.0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    consul (0.12.0)
+    consul (0.12.1)
       edge_rider (>= 0.3.0)
       memoizer
       rails

--- a/spec/rails-3.2/Gemfile.lock
+++ b/spec/rails-3.2/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    consul (0.12.0)
+    consul (0.12.1)
       edge_rider (>= 0.3.0)
       memoizer
       rails

--- a/spec/rails-4.1/Gemfile.lock
+++ b/spec/rails-4.1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    consul (0.12.0)
+    consul (0.12.1)
       edge_rider (>= 0.3.0)
       memoizer
       rails


### PR DESCRIPTION
after discussion:
We want powers like

```
  power :notes do
    Note.scoped(:conditions => { :client_id => client_ids })
  end
```

to raise an exception if

```
  power :clients do
    nil
  end
```

If `client_ids` would return an empty array `power.notes?` wouldn't return `false` as expected.
