### PR TITLE
before_action and around_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ class NotesController < ApplicationController
 end
 ```
 
-You can use `:except` and `:only` options like in before filters.
+You can use `:except` and `:only` options like in before\_actions.
 
 You can also map different powers to different actions:
 

--- a/lib/consul/controller.rb
+++ b/lib/consul/controller.rb
@@ -5,7 +5,11 @@ module Consul
       base.send :include, InstanceMethods
       base.send :extend, ClassMethods
       if ensure_power_initializer_present?
-        base.before_filter :ensure_power_initializer_present
+        if Rails.version.to_i < 4
+          base.before_filter :ensure_power_initializer_present
+        else
+          base.before_action :ensure_power_initializer_present
+        end
       end
     end
 
@@ -28,17 +32,29 @@ module Consul
       private
 
       def require_power_check(options = {})
-        before_filter :unchecked_power, options
+        if Rails.version.to_i < 4
+          before_filter :unchecked_power, options
+        else
+          before_action :unchecked_power, options
+        end
       end
 
       # This is badly named, since it doesn't actually skip the :check_power filter
       def skip_power_check(options = {})
-        skip_before_filter :unchecked_power, options
+        if Rails.version.to_i < 4
+          skip_before_filter :unchecked_power, options
+        else
+          skip_before_action :unchecked_power, options
+        end
       end
 
       def current_power(&initializer)
         self.current_power_initializer = initializer
-        around_filter :with_current_power
+        if Rails.version.to_i < 4
+          around_filter :with_current_power
+        else
+          around_action :with_current_power
+        end
         helper_method :current_power
       end
 
@@ -55,7 +71,11 @@ module Consul
         # Store arguments for testing
         (@consul_power_args ||= []) << args
 
-        before_filter :check_power, guard.filter_options
+        if Rails.version.to_i < 4
+          before_filter :check_power, guard.filter_options
+        else
+          before_action :check_power, guard.filter_options
+        end
 
         if guard.direct_access_method
           define_method guard.direct_access_method do


### PR DESCRIPTION
Use ```before_action```, ```around_action``` instead of ```before_filter```, ```around_filter``` syntax that will be deprecated in Rails 5.1

https://github.com/rails/rails/blob/v5.0.0.beta2/actionpack/lib/abstract_controller/callbacks.rb#L190-L193