### PR TITLE
Travis ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - "1.8.7"
   - "1.9.3"
   - "2.1.0"
+  - "2.2.6"
+  - "2.3.3"
   - ree
 before_install: gem install bundler # Fix bundler issues on 1.9.3
 before_script: rake travis_ci:prepare

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Consul is an authorization solution for Ruby on Rails where you describe *sets o
 We have used Consul in combination with [assignable_values](https://github.com/makandra/assignable_values) to solve a variety of authorization requirements ranging from boring to bizarre.
 Also see our crash course video: [Solving bizare authorization requirements with Rails](http://bizarre-authorization.talks.makandra.com/).
 
-Consul is tested with Rails 2.3, 3.0, 3.2 and 4.1 on Ruby 1.8.7, 1.9.3 and 2.1.0.
+Consul is tested with Rails 2.3, 3.0, 3.2 and 4.1 on Ruby 1.8.7, 1.9.3, 2.1.0, 2.2.6 and 2.3.3.
 
 
 Describing access to your application


### PR DESCRIPTION
Adds 2.2.6 and 2.3.3 to supported versions (we use consul with 2.3 without problem, want to make sure it stays that way)

Edit: had to pr this for it to run on Travis - looking into the failures, will update accordingly.