### PR TITLE
Support ActionController::API

### DIFF
--- a/lib/consul/controller.rb
+++ b/lib/consul/controller.rb
@@ -61,7 +61,10 @@ module Consul
         else
           around_action :with_current_power
         end
-        helper_method :current_power
+
+        if respond_to?(:helper_method)
+          helper_method :current_power
+        end
       end
 
       def consul_guards
@@ -132,5 +135,5 @@ module Consul
     end
 
   end
-  
+
 end


### PR DESCRIPTION
API applications use `ActionController::API` as their controller base
rather than `ActionController::Base`. `ActionController::API` does not
define `helper_method`. Attempting to use consul with these controllers
errors because `helper_method` is not defined.

This change calls `helper_method` only when its defined.