### PR TITLE
Do not depend on "rails" gem

### DIFF
--- a/Gemfile.5-2.lock
+++ b/Gemfile.5-2.lock
@@ -2,9 +2,11 @@ PATH
   remote: .
   specs:
     consul (1.0.3)
+      activerecord (>= 3.2)
+      activesupport (>= 3.2)
       edge_rider (>= 0.3.0)
       memoized (>= 1.0.2)
-      rails (>= 3.2)
+      railties (>= 3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -59,8 +61,8 @@ GEM
     crass (1.0.4)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
-    edge_rider (0.3.3)
-      activerecord
+    edge_rider (2.0.0)
+      activerecord (>= 3.2)
     erubi (1.8.0)
     gemika (0.5.0)
     globalid (0.4.2)

--- a/Gemfile.6-1.lock
+++ b/Gemfile.6-1.lock
@@ -2,9 +2,11 @@ PATH
   remote: .
   specs:
     consul (1.0.3)
+      activerecord (>= 3.2)
+      activesupport (>= 3.2)
       edge_rider (>= 0.3.0)
       memoized (>= 1.0.2)
-      rails (>= 3.2)
+      railties (>= 3.2)
 
 GEM
   remote: https://rubygems.org/

--- a/consul.gemspec
+++ b/consul.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('memoized', '>=1.0.2')
-  s.add_dependency('rails', '>=3.2')
+  s.add_dependency('activerecord', '>= 3.2')
+  s.add_dependency('activesupport', '>= 3.2')
+  s.add_dependency('railties', '>= 3.2')
   s.add_dependency('edge_rider', '>= 0.3.0')
 end


### PR DESCRIPTION
Closes #36

I identified following dependencies:
- `activerecord` because of `ActiveRecord::Base.send(:extend, Consul::ActiveRecord)`
- `activesupport` because of `ActiveSupport::TestCase.send :include, Consul::Spec::Matchers` and `present?`
-  `railties` because of `Rails.version` and `Rails.env`

I couldn't find any explicit dependencies on `actionpack`.