### PR TITLE
Changelog: Adjust release dates 2017->2018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 -
 
-## 0.14.1 - 2017-11-13
+## 0.14.1 - 2018-11-13
 
 ### Compatible changes
 
 - inherit power guards upon controller inheritance (fixes #40)
 
-## 0.14.0 - 2017-10-09
+## 0.14.0 - 2018-10-09
 
 ### Breaking changes
 
@@ -29,7 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - migrate tests to Gemika
 
-## 0.13.2 - 2017-10-02
+## 0.13.2 - 2018-10-02
 
 ### Compatible changes
 


### PR DESCRIPTION
Heyja! Thanks for keeping a changelog! I noticed that the dates might be off and probably should reference 2018 instead of 2017, is that correct?