### PR TITLE
Hook into railties correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+## 1.3.2 - 2023-08-27
+
+### Compatible changes
+
+- Hook into railties correctly
+
 ## 1.3.1 - 2023-02-28
 
 ### Compatible changes

--- a/Gemfile.5-2.lock
+++ b/Gemfile.5-2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    consul (1.3.1)
+    consul (1.3.2)
       activerecord (>= 3.2)
       activesupport (>= 3.2)
       edge_rider (>= 0.3.0)

--- a/Gemfile.6-1.lock
+++ b/Gemfile.6-1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    consul (1.3.1)
+    consul (1.3.2)
       activerecord (>= 3.2)
       activesupport (>= 3.2)
       edge_rider (>= 0.3.0)

--- a/Gemfile.7-0.lock
+++ b/Gemfile.7-0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    consul (1.3.1)
+    consul (1.3.2)
       activerecord (>= 3.2)
       activesupport (>= 3.2)
       edge_rider (>= 0.3.0)

--- a/Gemfile.7-1.lock
+++ b/Gemfile.7-1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    consul (1.3.1)
+    consul (1.3.2)
       activerecord (>= 3.2)
       activesupport (>= 3.2)
       edge_rider (>= 0.3.0)

--- a/lib/consul/active_record.rb
+++ b/lib/consul/active_record.rb
@@ -14,4 +14,6 @@ module Consul
   end
 end
 
-ActiveRecord::Base.send(:extend, Consul::ActiveRecord)
+ActiveSupport.on_load(:active_record) do
+  extend(Consul::ActiveRecord)
+end

--- a/lib/consul/version.rb
+++ b/lib/consul/version.rb
@@ -1,3 +1,3 @@
 module Consul
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end


### PR DESCRIPTION
Use `ActiveSupport.on_load` to not break the load order of Rails.